### PR TITLE
Popup streetview when heading arrows are click on

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -264,7 +264,7 @@ toggleHandlers["showHeading"] = GenerateBubbles(
     if (!(heading && accuracy)) {
       return;
     }
-    return new google.maps.Polyline({
+    const headingLine = new google.maps.Polyline({
       strokeColor: "#0000F0",
       strokeOpacity: 0.6,
       strokeWeight: 2,
@@ -273,6 +273,7 @@ toggleHandlers["showHeading"] = GenerateBubbles(
           icon: {
             path: google.maps.SymbolPath.FORWARD_CLOSED_ARROW,
             strokeColor: "#0000FF",
+            strokeWeight: 4,
           },
           offset: "100%",
         },
@@ -287,6 +288,23 @@ toggleHandlers["showHeading"] = GenerateBubbles(
         ),
       ],
     });
+    google.maps.event.addListener(headingLine, "click", () => {
+      console.log("gots click on", heading, rawLocationLatLng);
+      const panorama = new google.maps.StreetViewPanorama(
+        document.getElementById("map"),
+        {
+          position: rawLocationLatLng,
+          pov: { heading: heading, pitch: 10 },
+          addressControlOptions: {
+            position: google.maps.ControlPosition.BOTTOM_CENTER,
+          },
+          linksControl: false,
+          panControl: false,
+          enableCloseButton: true,
+        }
+      );
+    });
+    return headingLine;
   }
 );
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -20,6 +20,7 @@ let dataMakers = [];
 let trafficLayer;
 const bubbleMap = {};
 const toggleHandlers = {};
+let panorama;
 
 const render = (status: Status): ReactElement => {
   if (status === Status.LOADING) return <h3>{status} ..</h3>;
@@ -290,8 +291,9 @@ toggleHandlers["showHeading"] = GenerateBubbles(
       ],
     });
     google.maps.event.addListener(headingLine, "click", () => {
-      console.log("gots click on", heading, rawLocationLatLng);
-      const panorama = new google.maps.StreetViewPanorama(
+      // TODO: allow updating panorama based on forward/back
+      // stepper buttons (ie at each updatevehicle log we have a heading)
+      panorama = new google.maps.StreetViewPanorama(
         document.getElementById("map"),
         {
           position: rawLocationLatLng,


### PR DESCRIPTION
Ideally we'd squash the map element down to 1/2 size and show the
streetview side-by-side.  My JS skills aren't up to the task
so for now, the entire map view is replaced.

Uses heading from the the logs so that the streetview is properly 
orientated to the direction the vehicle was traveling at that point.


Fixes #8 