### PR TITLE
fix: minimal handling for overlapping trips #31

### DIFF
--- a/dune-buggy.js
+++ b/dune-buggy.js
@@ -57,7 +57,8 @@ const argv = yargs.argv;
 async function fetchTripLogsForVehicle(vehicleLogs, vehicle_id) {
   console.log("Loading trip logs for vehicle id", vehicle_id);
   const trip_ids = _(vehicleLogs)
-    .map((x) => _.get(x, "labels.trip_id"))
+    .map((x) => _.split(_.get(x, "labels.trip_id"), ","))
+    .flatten()
     .uniq()
     .compact()
     .value();


### PR DESCRIPTION
When a vehicle is on multiple trips the label in cloud logging
has all the trips in CSV.  Split those trips out to ensure logs
for all trips are gathered.  Future work to better visualize these
overlapping trips still needed.

Fixes #31 
