### PR TITLE
fix: Remove baked in apikey

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -16,6 +16,7 @@ let allMarkers = [];
 let map;
 let pathCoords;
 let rawLogs;
+let apikey;
 let dataMakers = [];
 let trafficLayer;
 const bubbleMap = {};
@@ -121,13 +122,10 @@ function getColor(trip_id) {
 function Map(props) {
   pathCoords = props.logData.pathCoords;
   rawLogs = props.logData.rawLogs;
+  apikey = props.logData.apikey;
 
   return (
-    <Wrapper
-      apiKey="AIzaSyACBHVQLegKXY5TOX0RcY0A_ugq3cAMmv4"
-      render={render}
-      libraries={["geometry"]}
-    >
+    <Wrapper apiKey={apikey} render={render} libraries={["geometry"]}>
       <MyMapComponent />
     </Wrapper>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,11 @@
 import ReactDOM from "react-dom";
 import App from "./App";
 import Map from "./Map";
-import rawLogs, { pathCoords } from "./vehicleData";
+import rawLogs, { pathCoords, apikey } from "./vehicleData";
 const logData = {
   pathCoords,
   rawLogs,
+  apikey,
 };
 
 ReactDOM.render(

--- a/src/vehicleData.js
+++ b/src/vehicleData.js
@@ -34,4 +34,6 @@ _.map(rawLogs, (le) => {
   le.timestampMS = le.date.getTime();
 });
 
-export { rawLogs as default, pathCoords };
+const apikey = parsedJsonData.APIKEY;
+
+export { rawLogs as default, pathCoords, apikey };


### PR DESCRIPTION
api key was already getting forwarded via generated datafile --
it just wasn't getting used.

The exposed api key has already been deleted
