### PR TITLE
feat: Process logs into logical trip segments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import {
   onSliderChangeMap,
   addMarkersToMapForData,
   updateMapToggles,
+  registerHandlers,
 } from "./Map";
 import Dataframe from "./Dataframe";
 import TimeSlider from "./TimeSlider";
@@ -41,6 +42,9 @@ class App extends React.Component {
       (timeRange) => this.onSliderChange(timeRange),
       25
     );
+
+    // Allow map code to set which object is featured
+    registerHandlers((fo) => this.setFeaturedObject(fo));
   }
 
   updateColumns(toggleName, jsonPaths) {
@@ -136,7 +140,14 @@ class App extends React.Component {
    */
   onSelectionChange(selectedRow) {
     addMarkersToMapForData(selectedRow);
-    this.setState({ featuredObject: selectedRow });
+    this.setFeaturedObject(selectedRow);
+  }
+
+  /*
+   * Set the featured object
+   */
+  setFeaturedObject(featuredObject) {
+    this.setState({ featuredObject: featuredObject });
   }
 
   /*

--- a/src/LogTable.js
+++ b/src/LogTable.js
@@ -85,14 +85,8 @@ const TrimCell = ({ value, trim }) => {
 function LogTable(props) {
   const minDate = props.timeRange.minDate;
   const maxDate = props.timeRange.maxDate;
-  // Filter entries to specified time range
-  const data = _(props.logData.rawLogs)
-    .filter((le) => {
-      return (
-        !minDate || (le.timestampMS >= minDate && le.timestampMS <= maxDate)
-      );
-    })
-    .reverse()
+  const data = props.logData.tripLogs
+    .getRawLogs_(new Date(minDate), new Date(maxDate))
     .value();
 
   const columns = React.useMemo(() => {

--- a/src/Trip.js
+++ b/src/Trip.js
@@ -1,0 +1,76 @@
+/*
+ * Trip.js
+ *
+ * Processed log for a trip. Currently only includes very basic information
+ * about the trip
+ */
+import _ from "lodash";
+
+class Trip {
+  constructor(tripIdx, tripName, firstUpdateTime) {
+    this.tripIdx = tripIdx;
+    this.tripName = tripName;
+    this.firstUpdateTime = firstUpdateTime;
+    this.updateRequests = 1;
+    this.pathCoords = [];
+    this.tripDuration = 0;
+    this.creationTime = "Unknown";
+    this.lastUpdateTime = "Unknown";
+  }
+
+  getFormatDuration() {
+    let sec_num = this.tripDuration / 1000;
+    let hours = Math.floor(sec_num / 3600);
+    let minutes = Math.floor((sec_num - hours * 3600) / 60);
+    let seconds = Math.floor(sec_num - hours * 3600 - minutes * 60);
+    let timeStr = "";
+
+    if (hours > 0) {
+      timeStr += hours + " hours ";
+    }
+    if (minutes > 0) {
+      timeStr += minutes + " minutes ";
+    }
+    if (seconds > 0) {
+      timeStr += seconds + " seconds";
+    }
+    return timeStr;
+  }
+
+  /*
+   * Returns data about trip to show in json viewer
+   */
+  getFeaturedData() {
+    return {
+      updateRequests: this.updateRequests,
+      tripName: this.tripName,
+      duration: this.getFormatDuration(),
+      creationTime: this.creationTime,
+      firstUpdateTime: this.firstUpdateTime,
+      lastUpdateTime: this.lastUpdateTime,
+    };
+  }
+
+  getPathCoords(minDate, maxDate) {
+    if (!(minDate && maxDate)) {
+      return this.pathCoords;
+    }
+    return _(this.pathCoords)
+      .filter((le) => {
+        return le.date >= minDate && le.date <= maxDate;
+      })
+      .value();
+  }
+
+  // append full raw log? would make downstream processing easier
+  // or synthesize pathCoords on the fly?
+  appendCoords(lastLocation, timestamp) {
+    this.pathCoords.push({
+      lat: lastLocation.rawLocation.latitude,
+      lng: lastLocation.rawLocation.longitude,
+      trip_id: this.tripName,
+      date: new Date(timestamp),
+    });
+  }
+}
+export { Trip as default };

--- a/src/TripLogs.js
+++ b/src/TripLogs.js
@@ -1,0 +1,180 @@
+/*
+ * TripLogs.js
+ *
+ * Processes raw logs into 'trip segments'.  A trip segment might
+ * be an individual trip, a contiguous non-trip region, or the route
+ * between two LMFS stops.
+ */
+import _ from "lodash";
+import Trip from "./Trip";
+
+const maxDistanceForDwell = 20; // meters
+const requiredUpdatesForDwell = 12; // aka 2 minute assuming update vehicle request at 10 seconds
+
+class TripLogs {
+  constructor(rawLogs, solutionType) {
+    this.solutionType = solutionType;
+    this.updateVehicleSuffix =
+      this.solutionType === "LMFS"
+        ? "update_delivery_vehicle"
+        : "update_vehicle";
+    this.trip_ids = [];
+    this.trips = [];
+    this.tripStatusChanges = [];
+    this.rawLogs = rawLogs;
+    this.processTripSegments();
+    this.minDate = new Date(rawLogs[0].timestamp);
+    this.maxDate = new Date(_.last(rawLogs).timestamp);
+  }
+
+  getRawLogs_(minDate, maxDate) {
+    minDate = minDate || this.minDate;
+    maxDate = maxDate || this.maxDate;
+    return _(this.rawLogs).filter(
+      (le) => le.date >= minDate && le.date <= maxDate
+    );
+  }
+
+  getTripStatusChanges() {
+    return this.tripStatusChanges;
+  }
+
+  getTripStatusAtDate(date) {
+    const idx = _.sortedIndexBy(this.tripStatusChanges, { date }, "date");
+    if (idx >= 1) {
+      return this.tripStatusChanges[idx - 1].newStatus;
+    }
+  }
+
+  getTripIDs() {
+    // TODO: do time filtering heree
+    return this.trip_ids;
+  }
+
+  getTrips() {
+    // TODO: do time filtering heree
+    return this.trips;
+  }
+
+  /*
+   * Rudimentary dwell location compution.  A lot of issues:
+   *    - Uses size of circle to represent dwell times ... which is confusing
+   *      w.r.t which points make up this cluster. (ie overlapping circles when
+   *      dwell locations are close by).  Should those dwell locations merged?
+   *    - Doesn't compute an actual dwell time, instead assumes UpdateVehicle requests
+   *      are 10 seconds apart
+   *    - A cluster should be within maxDistanceForDwell as well as maxTime in order to be considered
+   *      (right now clusters can be created at a location where multiple trips over days cross)
+   *    - dwell times are fuzzy. Sliders for the time & distance components might be interesting
+   *    - Doesn't respect min/max time filters from the time slider
+   *    - computation of dwell times is slow -- should cache results when turning on & off to avoid
+   *      unnecessary precomputation
+   *    - dwellLocations could be sarted by time to improve cluster lookup
+   *
+   *  See https://stackoverflow.com/questions/36928654/leader-clustering-algorithm-explanation for a
+   *  description of the very simplistic algo used here.
+   */
+  getDwellLocations(minDate, maxDate) {
+    const dwellLocations = [];
+    _.forEach(this.rawLogs, (le) => {
+      const lastLocation = _.get(le, "jsonPayload.response.lastLocation");
+      if (
+        !lastLocation ||
+        !lastLocation.rawLocation ||
+        le.date < minDate ||
+        le.date > maxDate
+      ) {
+        return;
+      }
+      const coord = {
+        lat: lastLocation.rawLocation.latitude,
+        lng: lastLocation.rawLocation.longitude,
+      };
+      const cluster = _.find(
+        dwellLocations,
+        (dl) =>
+          window.google.maps.geometry.spherical.computeDistanceBetween(
+            dl.leaderCoords,
+            new google.maps.LatLng(coord)
+          ) <= maxDistanceForDwell
+      );
+      if (cluster) {
+        cluster.updates++;
+      } else {
+        dwellLocations.push({
+          leaderCoords: new window.google.maps.LatLng(coord),
+          updates: 1,
+        });
+      }
+    });
+
+    return _.filter(
+      dwellLocations,
+      (dl) => dl.updates >= requiredUpdatesForDwell
+    );
+  }
+
+  getSegmentID(logEntry) {
+    if (this.solutionType === "LMFS") {
+      const stopsLeft = _.get(
+        logEntry,
+        "jsonPayload.response.remainingVehicleJourneySegments"
+      );
+      return stopsLeft && "Stops Left " + stopsLeft.length;
+    } else {
+      return _.get(logEntry, "labels.trip_id");
+    }
+  }
+
+  processTripSegments() {
+    let curTripId = "this is not a segment";
+    let curTripData = undefined;
+    let tripIdx = 0;
+    let nonTripIdx = 0;
+    let lastTripStatus = "no status";
+    // assumes logs are already sorted
+    // also assumes out-of-order updates can't happen.  Unclear
+    // if this is a good assumption, but it might be worth it to call out
+    // places where it happens (since that might actually be a client bug).
+
+    _.forEach(this.rawLogs, (le) => {
+      if (le.logName.match(this.updateVehicleSuffix)) {
+        const newTripId = this.getSegmentID(le);
+        if (newTripId !== curTripId) {
+          curTripId = newTripId;
+          const tripName = newTripId
+            ? newTripId
+            : "non-trip-segment-" + nonTripIdx;
+          curTripData = new Trip(tripIdx, tripName, new Date(le.timestamp));
+          this.trips.push(curTripData);
+          this.trip_ids.push(curTripData.tripName);
+
+          tripIdx++;
+          if (newTripId === undefined) {
+            nonTripIdx++;
+          }
+        } else {
+          curTripData.lastUpdateTime = new Date(le.timestamp);
+          curTripData.tripDuration =
+            curTripData.lastUpdateTime - curTripData.firstUpdateTime;
+          curTripData.updateRequests++;
+        }
+        const lastLocation = le.jsonPayload.response.lastLocation;
+        if (lastLocation && lastLocation.rawLocation) {
+          curTripData.appendCoords(lastLocation, le.timestamp);
+        }
+      }
+      const tripStatus = _.get(le, "jsonPayload.response.status");
+      // if the logs had a trip status, and it changeed update
+      if (tripStatus && tripStatus !== lastTripStatus) {
+        this.tripStatusChanges.push({
+          newStatus: tripStatus,
+          date: new Date(le.timestamp),
+        });
+        lastTripStatus = tripStatus;
+      }
+    });
+  }
+}
+
+export { TripLogs as default };

--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,10 @@
 import ReactDOM from "react-dom";
 import App from "./App";
 import Map from "./Map";
-import rawLogs, {
-  pathCoords,
-  apikey,
-  jwt,
-  projectId,
-  solutionType,
-} from "./vehicleData";
+import { tripLogs, apikey, jwt, projectId, solutionType } from "./vehicleData";
 
 const logData = {
-  pathCoords,
-  rawLogs,
+  tripLogs,
   apikey,
   jwt,
   projectId,

--- a/src/vehicleData.js
+++ b/src/vehicleData.js
@@ -8,37 +8,13 @@
  */
 import _ from "lodash";
 import parsedJsonData from "./rawData";
-const rawLogs = parsedJsonData.rawLogs;
+const rawLogs = _.reverse(parsedJsonData.rawLogs);
 const jwt = parsedJsonData.jwt;
 const projectId = parsedJsonData.projectId;
 const apikey = parsedJsonData.APIKEY;
 const solutionType = parsedJsonData.solutionType;
+import TripLogs from "./TripLogs";
 
-//TODO refactor log processing, remove logic from
-//Map.js, expose things ilke groupingLabel?
-//const groupingLabel = solutionType === "ODRD" ? "trip_id" : "task_id";
-const updateVehicleSuffix =
-  solutionType === "LMFS" ? "update_delivery_vehicle" : "update_vehicle";
-
-// TODO: handle non-trip segments (ie online, but not trip
-// assigned).
-const pathCoords = _(parsedJsonData.rawLogs)
-  .filter(
-    (l) =>
-      l.logName.endsWith(updateVehicleSuffix) &&
-      _.get(l, "jsonPayload.response.lastLocation.rawLocation")
-  )
-  .map((l) => {
-    const lastLocation = l.jsonPayload.response.lastLocation;
-    return {
-      lat: lastLocation.rawLocation.latitude,
-      lng: lastLocation.rawLocation.longitude,
-      trip_id: l.labels.trip_id,
-      task_id: l.labels.task_id,
-      date: new Date(l.timestamp),
-    };
-  })
-  .value();
 //  annotate with Dates & timestapms
 _.map(rawLogs, (le) => {
   le.date = new Date(le.timestamp);
@@ -46,4 +22,5 @@ _.map(rawLogs, (le) => {
   le.timestampMS = le.date.getTime();
 });
 
-export { rawLogs as default, pathCoords, apikey, jwt, projectId, solutionType };
+const tripLogs = new TripLogs(rawLogs, solutionType);
+export { tripLogs, apikey, jwt, projectId, solutionType };


### PR DESCRIPTION
This change refactors how trips our visualized:
  - trips are now broken up into trip & not trip segments
  - Added TripLogs and Trip classes
  - Removed duplicated processing
  - Fixed issues with dwellTimes not respecting the time slider
  - Add trip status to the timeslider
  - Addressed trip coloring
  - Added highlight & click functionality to the trip polylines
  - Updated last vehicle location to fancy image icon
  - Removed start/end trip markers (not necessary with new
    trip highlighting/click functionality)
  - continued trend of very minimal LMFS support.  TripLogs
    likely needs to be renamed 'VehicleLogs' and refactored into
    Trip/Task components.   For now this at least gives visualization
    where separate stops are colored separately


Addresses issues:
https://github.com/googlemaps/fleet-debugger/issues/34
https://github.com/googlemaps/fleet-debugger/issues/37
