### PR TITLE
fix: use location from request, not response

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -209,7 +209,7 @@ function addMarkersToMapForData(data) {
 
   const rawLocation = _.get(
     data,
-    "jsonPayload.response.lastLocation.rawLocation"
+    "jsonPayload.request.vehicle.lastLocation.rawLocation"
   );
   if (rawLocation) {
     const status = _.get(data, "jsonPayload.response.status");
@@ -239,7 +239,10 @@ function GenerateBubbles(bubbleName, cb) {
       bubbleMap[bubbleName] = tripLogs
         .getRawLogs_(minDate, maxDate)
         .map((le) => {
-          const lastLocation = _.get(le, "jsonPayload.response.lastLocation");
+          const lastLocation = _.get(
+            le,
+            "jsonPayload.request.vehicle.lastLocation"
+          );
           let rawLocation;
           let bubble = undefined;
           if (lastLocation && (rawLocation = lastLocation.rawLocation)) {

--- a/src/TripLogs.js
+++ b/src/TripLogs.js
@@ -77,7 +77,10 @@ class TripLogs {
   getDwellLocations(minDate, maxDate) {
     const dwellLocations = [];
     _.forEach(this.rawLogs, (le) => {
-      const lastLocation = _.get(le, "jsonPayload.response.lastLocation");
+      const lastLocation = _.get(
+        le,
+        "jsonPayload.request.vehicle.lastLocation"
+      );
       if (
         !lastLocation ||
         !lastLocation.rawLocation ||
@@ -159,7 +162,10 @@ class TripLogs {
             curTripData.lastUpdateTime - curTripData.firstUpdateTime;
           curTripData.updateRequests++;
         }
-        const lastLocation = le.jsonPayload.response.lastLocation;
+        const lastLocation = _.get(
+          le,
+          "jsonPayload.request.vehicle.lastLocation"
+        );
         if (lastLocation && lastLocation.rawLocation) {
           curTripData.appendCoords(lastLocation, le.timestamp);
         }


### PR DESCRIPTION
When visualizing jumps using the location in the
response will show spurious jumps in this case:

1) update vehicle  (location in field mask)
2) Long time gap (ie app crashes, offline, etc)
3) update vehicle (non-location properties in fieldmask)
4) update vehicle (location in field mask)

In step 3, the location in the response will be the location
from step 1 -- and thus very stale.
