### PR TITLE
feat: visualize jumps

### DIFF
--- a/src/HighVelocityJump.js
+++ b/src/HighVelocityJump.js
@@ -1,0 +1,115 @@
+/*
+ * HighVelocityJump.js
+ *
+ * Representation of a HighVelocityJump
+ */
+import _ from "lodash";
+const velocityOutlier = 68; // true velocities higher than this unlikely (in Meters/sec aprrox 150 MPH)
+import Stats from "./Stats";
+let computedOutlier = 0;
+
+class HighVelocityJump {
+  constructor(jumpIdx, prevEntry, curEntry) {
+    const prevLoc = _.get(
+      prevEntry,
+      "jsonPayload.request.vehicle.lastLocation"
+    );
+    const curLoc = _.get(curEntry, "jsonPayload.request.vehicle.lastLocation");
+    const startLoc = new google.maps.LatLng({
+      lat: prevLoc.rawLocation.latitude,
+      lng: prevLoc.rawLocation.longitude,
+    });
+    const endLoc = new google.maps.LatLng({
+      lat: curLoc.rawLocation.latitude,
+      lng: curLoc.rawLocation.longitude,
+    });
+    const distanceTraveled =
+      window.google.maps.geometry.spherical.computeDistanceBetween(
+        startLoc,
+        endLoc
+      );
+    const timeSpentMS = curEntry.date - prevEntry.date;
+    const velocity = distanceTraveled / (timeSpentMS / 1000.0);
+    this.entry = curEntry;
+    this.prevEntry = prevEntry;
+    this.timeSpentMS = timeSpentMS;
+    this.distanceTraveled = distanceTraveled;
+    this.velocity = velocity;
+    this.startLoc = startLoc;
+    this.startDate = prevEntry.date;
+    this.endDate = curEntry.date;
+    this.endLoc = endLoc;
+    this.jumpIdx = jumpIdx;
+  }
+
+  /*
+   * Returns data about the jump to show in json viewer
+   */
+  getFeaturedData() {
+    return {
+      timeSpentMS: this.timeSpentMS,
+      distanceTraveled: this.distanceTraveled,
+      velocity: this.velocity,
+      velocityMPH: this.velocity * 2.237,
+      startLoc: this.startLoc.toString(),
+      startDate: this.prevEntry.date,
+      endDate: this.entry.date,
+      endLoc: this.endLoc.toString(),
+      jumpIdx: this.jumpIdx,
+      date: this.entry.date,
+      computedOutlierVelocity: computedOutlier,
+    };
+  }
+
+  /*
+   * returns blob of data suitable for viewing in
+   * the log viewer
+   */
+  getLogViewerEntry() {
+    const featureData = this.getFeaturedData();
+    // Add properties necessary for logviewer to
+    // function
+    featureData.timestampMS = this.startDate.getTime();
+    featureData.formattedDate = this.startDate.toISOString();
+    featureData.jsonPayload = {
+      "@type": "Jump",
+      request: {
+        vehicle: {
+          lastLocation: {
+            speed: this.velocity,
+          },
+        },
+      },
+    };
+    return featureData;
+  }
+
+  /*
+   * Filters jumps down to instances where the vehicle was
+   * travelling at an unrealistic speed (either
+   * greater that 150 MPH, or 100x median velocity).
+   *
+   * These numbers were chosen somewhat arbitrarily
+   * based on a small dataset.
+   */
+  static getSignificantJumps(jumps) {
+    if (!jumps) {
+      return [];
+    }
+    const velocities = _.map(jumps, "velocity");
+    const avgVelocity = _.mean(velocities);
+    const medianVelocity = Stats.median(velocities);
+    const minVelocity = _.min(velocities);
+    const maxVelocity = _.max(velocities);
+    console.log("avgVelocity", avgVelocity);
+    console.log("medianVelocity", medianVelocity);
+    console.log("minVelocity", minVelocity);
+    console.log("maxVelocity", maxVelocity);
+    computedOutlier = _.min([velocityOutlier, medianVelocity * 100]);
+    return _(jumps)
+      .filter((e) => e.velocity >= computedOutlier)
+      .sortBy("velocity")
+      .value();
+  }
+}
+export { HighVelocityJump as default };

--- a/src/LogTable.js
+++ b/src/LogTable.js
@@ -83,10 +83,10 @@ const TrimCell = ({ value, trim }) => {
 };
 
 function LogTable(props) {
-  const minDate = props.timeRange.minDate;
-  const maxDate = props.timeRange.maxDate;
+  const minTime = props.timeRange.minTime;
+  const maxTime = props.timeRange.maxTime;
   const data = props.logData.tripLogs
-    .getRawLogs_(new Date(minDate), new Date(maxDate))
+    .getLogs_(new Date(minTime), new Date(maxTime))
     .value();
 
   const columns = React.useMemo(() => {

--- a/src/MissingUpdate.js
+++ b/src/MissingUpdate.js
@@ -1,0 +1,120 @@
+/*
+ * MissingUpdate.js
+ *
+ * Representation of a missing update
+ */
+import _ from "lodash";
+const updateOutlier = 60000; // 60 seconds
+import Stats from "./Stats";
+import Utils from "./Utils";
+let computedOutlier = 0;
+
+class MissingUpdate {
+  constructor(idx, prevEntry, curEntry) {
+    const interval = curEntry.date - prevEntry.date;
+    const curLoc = _.get(curEntry, "jsonPayload.request.vehicle.lastLocation");
+    const prevLoc = _.get(
+      prevEntry,
+      "jsonPayload.request.vehicle.lastLocation"
+    );
+    const startLoc = new google.maps.LatLng({
+      lat: prevLoc.rawLocation.latitude,
+      lng: prevLoc.rawLocation.longitude,
+    });
+    const endLoc = new google.maps.LatLng({
+      lat: curLoc.rawLocation.latitude,
+      lng: curLoc.rawLocation.longitude,
+    });
+    this.entry = curEntry;
+    this.prevEntry = prevEntry;
+    this.interval = interval;
+    this.startLoc = startLoc;
+    this.startDate = prevEntry.date;
+    this.endDate = curEntry.date;
+    this.endLoc = endLoc;
+    this.idx = idx;
+    this.startVehicleState = _.get(curEntry, "jsonPayload.response.state");
+    this.endVehicleState = _.get(prevEntry, "jsonPayload.response.state");
+    this.duration = Utils.formatDuration(this.interval);
+  }
+
+  /*
+   * Returns data about the update to show in json viewer
+   */
+  getFeaturedData() {
+    return {
+      duration: this.duration,
+      interval: this.interval,
+      startDate: this.startDate,
+      startLoc: this.startLoc.toString(),
+      endDate: this.endDate,
+      endLoc: this.endLoc.toString(),
+      startVehicleState: this.startVehicleState,
+      endVehicleState: this.endVehicleState,
+      computedOutlier: Utils.formatDuration(computedOutlier),
+    };
+  }
+
+  /*
+   * format a vehicle state transitino into something a
+   * human can easily read.
+   */
+  getStateTransition() {
+    const start = this.startVehicleState.replace("VEHICLE_STATE_", "");
+    const end = this.endVehicleState.replace("VEHICLE_STATE_", "");
+    return start + ">" + end;
+  }
+
+  /*
+   * returns blob of data suitable for viewing in
+   * the log viewer
+   */
+  getLogViewerEntry() {
+    const featureData = this.getFeaturedData();
+    // Add properties necessary for logviewer to
+    // function
+    featureData.date = this.startDate;
+    featureData.timestampMS = this.startDate.getTime();
+    featureData.formattedDate = this.startDate.toISOString();
+    featureData.jsonPayload = {
+      "@type": "Missing Updates",
+      temporal_gap: featureData.duration,
+      response: {
+        state: this.getStateTransition(),
+      },
+    };
+    return featureData;
+  }
+
+  /*
+   * Filters updates down to instances where now updates
+   * were received from the vehicle for either 60 seconds
+   * or 10x the median observed update (our default
+   * update is every 5 seconds).
+   *
+   * These numbers were chosen somewhat arbitrarily
+   * based on a small dataset.
+   */
+  static getSignificantMissingUpdates(updates) {
+    if (!updates) {
+      return [];
+    }
+    const intervals = _.map(updates, "interval");
+    const avgInternal = _.mean(intervals);
+    const medianInternal = Stats.median(intervals);
+    const minInternal = _.min(intervals);
+    const maxInternal = _.max(intervals);
+    console.log("avgInternal", avgInternal);
+    console.log("medianInternal", medianInternal);
+    console.log("minInternal", minInternal);
+    console.log("maxInternal", maxInternal);
+    console.log("updateOutlier", updateOutlier);
+    computedOutlier = _.min([medianInternal * 10, updateOutlier]);
+    console.log("computedOutlier", computedOutlier);
+    return _(updates)
+      .filter((e) => e.interval >= computedOutlier)
+      .sortBy("interval")
+      .value();
+  }
+}
+export { MissingUpdate as default };

--- a/src/Stats.js
+++ b/src/Stats.js
@@ -1,0 +1,14 @@
+/*
+ * stats helpers
+ */
+class Stats {
+  static median(dataSet) {
+    if (dataSet.length === 1) return dataSet[0];
+    const sorted = [...dataSet].sort();
+    const ceil = Math.ceil(sorted.length / 2);
+    const floor = Math.floor(sorted.length / 2);
+    if (ceil === floor) return sorted[floor];
+    return (sorted[ceil] + sorted[floor]) / 2;
+  }
+}
+export { Stats as default };

--- a/src/TimeSlider.js
+++ b/src/TimeSlider.js
@@ -29,10 +29,13 @@ function TimeSlider(props) {
   const minVal = tripLogs.minDate.getTime();
   const maxVal = tripLogs.maxDate.getTime();
 
+  const curMin = _.max([minVal, props.curMin]);
+  const curMax = _.min([maxVal, props.curMax]);
+
   function onChange(value) {
     props.onSliderChange({
-      minDate: value[0],
-      maxDate: value[1],
+      minTime: value[0],
+      maxTime: value[1],
     });
   }
 
@@ -51,6 +54,7 @@ function TimeSlider(props) {
         step={1}
         onChange={onChange}
         defaultValue={[minVal, maxVal]}
+        value={[curMin, curMax]}
         tipFormatter={formatTooltip}
       />
     </div>

--- a/src/ToggleBar.js
+++ b/src/ToggleBar.js
@@ -39,6 +39,18 @@ function ToggleBar(props) {
       >
         Dwell Locations
       </ButtonToggle>
+      <ButtonToggle
+        active={props.showHighVelocityJumps}
+        onClick={props.onClickHighVelocityJumps}
+      >
+        Jumps (unrealistic velocity)
+      </ButtonToggle>
+      <ButtonToggle
+        active={props.showMissingUpdates}
+        onClick={props.onClickMissingUpdates}
+      >
+        Jumps (Temporal)
+      </ButtonToggle>
       <ButtonToggle active={props.showTraffic} onClick={props.onClickTraffic}>
         Traffic
       </ButtonToggle>

--- a/src/Trip.js
+++ b/src/Trip.js
@@ -5,40 +5,22 @@
  * about the trip
  */
 import _ from "lodash";
+import Utils from "./Utils";
 
 class Trip {
-  constructor(tripIdx, tripName, firstUpdateTime) {
+  constructor(tripIdx, tripName, firstUpdate) {
     this.tripIdx = tripIdx;
     this.tripName = tripName;
-    this.firstUpdateTime = firstUpdateTime;
     this.updateRequests = 1;
     this.pathCoords = [];
     this.tripDuration = 0;
     this.creationTime = "Unknown";
-    this.lastUpdateTime = "Unknown";
+    this.firstUpdate = firstUpdate;
+    this.lastUpdate = "Unknown";
   }
 
   getTraveledDistance() {
     return window.google.maps.geometry.spherical.computeLength(this.pathCoords);
-  }
-
-  getFormatDuration() {
-    let sec_num = this.tripDuration / 1000;
-    let hours = Math.floor(sec_num / 3600);
-    let minutes = Math.floor((sec_num - hours * 3600) / 60);
-    let seconds = Math.floor(sec_num - hours * 3600 - minutes * 60);
-    let timeStr = "";
-
-    if (hours > 0) {
-      timeStr += hours + " hours ";
-    }
-    if (minutes > 0) {
-      timeStr += minutes + " minutes ";
-    }
-    if (seconds > 0) {
-      timeStr += seconds + " seconds";
-    }
-    return timeStr;
   }
 
   /*
@@ -48,12 +30,12 @@ class Trip {
     return {
       updateRequests: this.updateRequests,
       tripName: this.tripName,
-      duration: this.getFormatDuration(),
+      duration: Utils.formatDuration(this.tripDuration),
       creationTime: this.creationTime,
-      firstUpdateTime: this.firstUpdateTime,
-      lastUpdateTime: this.lastUpdateTime,
       traveledDistanceKilometers: this.getTraveledDistance() / 1000,
       traveledDistanceMiles: this.getTraveledDistance() / 1609,
+      firstUpdate: this.firstUpdate,
+      lastUpdate: this.lastUpdate,
     };
   }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,0 +1,25 @@
+class Utils {
+  /*
+   * Formats a duration into something friendly
+   * for human consumption.
+   */
+  static formatDuration(duration) {
+    let sec_num = duration / 1000;
+    let hours = Math.floor(sec_num / 3600);
+    let minutes = Math.floor((sec_num - hours * 3600) / 60);
+    let seconds = Math.floor(sec_num - hours * 3600 - minutes * 60);
+    let timeStr = "";
+
+    if (hours > 0) {
+      timeStr += hours + " hours ";
+    }
+    if (minutes > 0) {
+      timeStr += minutes + " minutes ";
+    }
+    if (seconds > 0) {
+      timeStr += seconds + " seconds";
+    }
+    return timeStr;
+  }
+}
+export { Utils as default };

--- a/src/vehicleData.js
+++ b/src/vehicleData.js
@@ -16,10 +16,11 @@ const solutionType = parsedData.solutionType;
 import TripLogs from "./TripLogs";
 
 //  annotate with Dates & timestapms
-_.map(rawLogs, (le) => {
+_.map(rawLogs, (le, idx) => {
   le.date = new Date(le.timestamp);
-  le.formattedDate = le.date.toString();
+  le.formattedDate = le.date.toISOString();
   le.timestampMS = le.date.getTime();
+  le.idx = idx;
 });
 
 const tripLogs = new TripLogs(rawLogs, solutionType);


### PR DESCRIPTION
This change adds two different types of jump visualizations:
  * high-velocity jumps: locations where between two updates
    the calculated straight line speed of the vehicle exceeded a
    reasonable speed.   Visualized as an arrow with click &
    mouse over actions
  * missing updates: places where no location updates were recevied.
    This could be due to cell signal problems, device going offline,
    etc.  Visualized as offset lines (like dimentions on an architectural
    drawing) -- which seems to better show the temporal only jumps.
    Click & mouseover actions are supported

Other changes include:
  * expose ability to set the timeslider range
  * click handlers for jumps & trips now focus timeslider
    and log viewer onto the range in question
  * cleanup some minDate/maxDate vars that were really time values

Fixes #36 
