### PR TITLE
fix: override maxZoom hardcoded by journeysharing provider

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -151,6 +151,7 @@ function MyMapComponent() {
     } else {
       map.fitBounds(vehicleBounds);
     }
+    map.setOptions({ maxZoom: 100 });
     map.addListener("zoom_changed", () => {
       setQueryStringValue("zoom", map.getZoom());
     });


### PR DESCRIPTION
When debugging it's often useful to zoom much closer in than the
maxZoom=17 hardcoded.
