### PR TITLE
Add app engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ src/rawData.js
 public/data.json
 build/
 cloud-run/fleet-debugger
+appengine/fleet-debugger

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -1,0 +1,14 @@
+# Fleet Debugger App Engine Example
+
+This demonstrates how fleet-debugger could be deployed via app engine.  App engine
+service accounts will need to be configured to allow access to the datastore for
+logs (ie cloud logging or bigquery).
+
+The endpoints exposed are not authenticated and will need to be protected by something
+like Cloud Identity Aware Proxy.
+
+## Deploying
+
+```
+./deploy.sh
+```

--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,0 +1,15 @@
+# Copyright 2022, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: nodejs16
+service: fleet-debugger

--- a/appengine/deploy.sh
+++ b/appengine/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+rm -rf ./fleet-debugger
+mkdir fleet-debugger
+(cd .. && npm run build)
+cp -a ../build fleet-debugger
+cp -a ../dune-buggy.js ./fleet-debugger/index.js
+cp -a ../components ./fleet-debugger/
+cp package.json ./fleet-debugger
+cp app.yaml ./fleet-debugger
+cp fleet-debugger.sh ./fleet-debugger/
+echo env_variables: >> ./fleet-debugger/app.yaml
+echo "   APIKEY: \"$APIKEY\"" >> ./fleet-debugger/app.yaml
+(cd ./fleet-debugger && gcloud app deploy)

--- a/appengine/fleet-debugger.sh
+++ b/appengine/fleet-debugger.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node index.js serve --apikey=$APIKEY --port=$PORT --daysAgo=30

--- a/appengine/package.json
+++ b/appengine/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "fleet-debugger",
+  "version": "1.0.0",
+  "description": "fleet-debugger LIVE",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googlemaps/fleet-debugger.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/googlemaps/fleet-debugger/issues"
+  },
+  "engines": {
+    "node": ">= 16.0.0"
+  },
+  "homepage": ".",
+  "dependencies": {
+    "@google-cloud/logging": "^9.6.1",
+    "express": "^4.18.1",
+    "google-maps-react": "^2.0.6",
+    "googleapis": "^89.0.0",
+    "lodash": "^4.17.21",
+    "open": "^8.3.0",
+    "yargs": "^17.2.1"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.2.0",
+    "@typescript-eslint/parser": "^5.2.0",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jest": "^25.2.2",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.26.1",
+    "typescript": "^4.4.4"
+  },
+  "scripts": {
+    "start": "sh ./fleet-debugger.sh"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}


### PR DESCRIPTION
Allows fleet-debugger to be deployed to app-engine.   With this change fleet-debugger could run along side our sample apps.