### PR TITLE
fix several data fetching issues and also a data discrepancy for task…

### DIFF
--- a/components/bigqueryDS.js
+++ b/components/bigqueryDS.js
@@ -237,7 +237,7 @@ LIMIT 5000
     return data.map(normalize);
   }
 
-  async fetchVehicleLogs(vehicle_id, trip_id) {
+  async fetchVehicleAndTripLogs(vehicle_id, trip_id) {
     // TODO: handle case where table doesn't exist (ie in a lmfs project)
     let whereClause;
     const params = {
@@ -283,7 +283,12 @@ LIMIT
     const updateData = await this.bq(updateQuery, params);
     const data = createData.concat(updateData);
     console.log(`found ${data.length} ODRD vehicle logs`);
-    return data.map(normalize);
+    const vehicleLogs = data.map(normalize);
+    const tripLogs = await this.fetchTripLogsForVehicle(
+      vehicle_id,
+      vehicleLogs
+    );
+    return _.concat(vehicleLogs, tripLogs);
   }
 
   async fetchDeliveryVehicleLogs(delivery_vehicle_id) {

--- a/components/cloudLoggingDS.js
+++ b/components/cloudLoggingDS.js
@@ -90,12 +90,14 @@ class CloudLogs extends Datasource {
     return taskLogs;
   }
 
-  async fetchVehicleLogs(vehicle, trip) {
+  async fetchVehicleAndTripLogs(vehicle, trip) {
     const label = vehicle ? "vehicle_id" : "trip_id";
     const labelVal = vehicle ? vehicle : trip;
 
     console.log(`Fetching logs for ${label} = ${labelVal}`);
-    return await logging.fetchLogs(label, [labelVal], this.argv.daysAgo);
+    const logs = await logging.fetchLogs(label, [labelVal], this.argv.daysAgo);
+    const tripLogs = await this.fetchTripLogsForVehicle(vehicle, logs);
+    return _.concat(logs, tripLogs);
   }
 
   async fetchDeliveryVehicleLogs(deliveryVehicle, vehicleLogs) {

--- a/components/datasource.js
+++ b/components/datasource.js
@@ -19,20 +19,16 @@ class Datasource {
     this.argv = argv;
   }
 
-  async fetchTripLogsForVehicle(vehicle_id, vehicleLogs) {
-    throw new Error("Not Implemented", vehicle_id, vehicleLogs);
-  }
-
-  async fetchTaskLogsForVehicle(vehicle_id, vehicleLogs) {
-    throw new Error("Not Implemented", vehicle_id, vehicleLogs);
-  }
-
-  async fetchVehicleLogs(vehicle, trip) {
+  async fetchVehicleAndTripLogs(vehicle, trip) {
     throw new Error("Not Implemented", vehicle, trip);
   }
 
   async fetchDeliveryVehicleLogs(deliveryVehicle, vehicleLogs) {
     throw new Error("Not Implemented", deliveryVehicle, vehicleLogs);
+  }
+
+  async fetchTaskLogsForVehicle(vehicle_id, vehicleLogs) {
+    throw new Error("Not Implemented", vehicle_id, vehicleLogs);
   }
 }
 

--- a/components/fleetArchiveDS.js
+++ b/components/fleetArchiveDS.js
@@ -127,7 +127,11 @@ class FleetArchiveLogs extends Datasource {
     );
 
     if (vehicle) {
-      const tripLogs = await this.fetchTripLogsForVehicle(vehicle, entries, jwt);
+      const tripLogs = await this.fetchTripLogsForVehicle(
+        vehicle,
+        entries,
+        jwt
+      );
       return _.concat(entries, tripLogs);
     }
 
@@ -148,9 +152,7 @@ class FleetArchiveLogs extends Datasource {
 
     let all_filtered_vehicle_entries = [];
     for (const vehicleId of vehicleIds) {
-      console.log(
-        `Fetching logs for vehicle ${vehicleId}`
-      );
+      console.log(`Fetching logs for vehicle ${vehicleId}`);
       const vehicle_entries = await logging.fetchLogsFromArchive(
         "vehicles",
         vehicleId,

--- a/src/Task.js
+++ b/src/Task.js
@@ -7,9 +7,9 @@
 import _ from "lodash";
 
 class Task {
-  constructor(date, taskIdx, taskReq, taskResp) {
+  constructor(date, taskIdx, taskId, taskReq, taskResp) {
     this.taskIdx = taskIdx;
-    this.taskId = taskReq.taskid;
+    this.taskId = taskId;
     this.updates = [];
     this.firstUpdate = date;
     this.addUpdate(date, taskReq, taskResp);

--- a/src/TaskLogs.js
+++ b/src/TaskLogs.js
@@ -27,7 +27,7 @@ class TaskLogs {
         const taskReq = le.request;
         const taskResp = le.response;
         const taskNameRegex = new RegExp(`.*/tasks/(.*)$`, "i");
-        const taskName = _.get(taskReq, "task.name");
+        const taskName = _.get(taskResp, "name");
         if (taskName) {
           const match = taskName.match(taskNameRegex);
           if (match) {
@@ -37,6 +37,7 @@ class TaskLogs {
               task = this.tasks[taskId] = new Task(
                 le.date,
                 taskIdx,
+                taskId,
                 taskReq,
                 taskResp
               );

--- a/src/TaskLogs.js
+++ b/src/TaskLogs.js
@@ -26,16 +26,24 @@ class TaskLogs {
       .forEach((le, taskIdx) => {
         const taskReq = le.request;
         const taskResp = le.response;
-        let task = this.tasks[taskReq.taskid];
-        if (!task) {
-          task = this.tasks[taskReq.taskid] = new Task(
-            le.date,
-            taskIdx,
-            taskReq,
-            taskResp
-          );
-        } else {
-          task.addUpdate(le.date, taskReq, taskResp);
+        const taskNameRegex = new RegExp(`.*/tasks/(.*)$`, "i");
+        const taskName = _.get(taskReq, "task.name");
+        if (taskName) {
+          const match = taskName.match(taskNameRegex);
+          if (match) {
+            const taskId = match[1];
+            let task = this.tasks[taskId];
+            if (!task) {
+              task = this.tasks[taskId] = new Task(
+                le.date,
+                taskIdx,
+                taskReq,
+                taskResp
+              );
+            } else {
+              task.addUpdate(le.date, taskReq, taskResp);
+            }
+          }
         }
       });
   }

--- a/src/TaskLogs.test.js
+++ b/src/TaskLogs.test.js
@@ -113,13 +113,11 @@ test("fleet archive lmfs task log loading", async () => {
   expect(taskLogs.getTasks().map("taskid").value()).toStrictEqual([
     "sample-vehicle-id-1",
     "sample-vehicle-id-2",
-    undefined,
   ]);
 
   expect(taskLogs.getTasks().map("taskoutcome").value()).toStrictEqual([
-    undefined,
-    undefined,
     "SUCCEEDED",
+    undefined,
   ]);
 
   expect(
@@ -130,5 +128,5 @@ test("fleet archive lmfs task log loading", async () => {
           t.plannedVsActualDeltaMeters && parseInt(t.plannedVsActualDeltaMeters)
       )
       .value()
-  ).toStrictEqual([undefined, undefined, 0]);
+  ).toStrictEqual([0, undefined]);
 });


### PR DESCRIPTION
1. Modify fetching API function names to better match what they actually do. Merged the fetch vehicle and trip log functions into one.
2. Set modifying_calls_only=true to only fetch create and update entries in Fleet Archive.
3. Brought back page_size=50 since without it, the servers were defaulting to 10 which was causing fetching to become slow. According to the proto comments, this parameter is only a "max page size" suggestion anyway.
4. Added some console print statements to update progress on data fetching and how long it took.
5. Fixed a data discrepancy in the frontend UI that was causing task flags to not show up.