### PR TITLE
build: workflow versions to v19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,21 +32,23 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
       - name: Test
-        run: |
-          npm i
-          npm run lint
-          npm test
+        run: npm test
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
+          semantic_version: 19.0.5
           extra_plugins: |
-            @semantic-release/commit-analyzer
+            @semantic-release/commit-analyzer@5.0.0
             semantic-release-interval
-            @semantic-release/release-notes-generator
+            @semantic-release/release-notes-generator@10.0.0
             @semantic-release/git
-            @semantic-release/github
-            @semantic-release/npm
+            @semantic-release/github@8.0.0
+            @semantic-release/npm@9.0.0
             @googlemaps/semantic-release-config
             semantic-release-npm-deprecate
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm i
-      - run: npm run lint
-      - run: npm test
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Ideally we would update the version for the dependency semantic-release in semantic-release-config to v20.