### PR TITLE
feat: use response location sensor for table and map

### DIFF
--- a/src/Dataframe.js
+++ b/src/Dataframe.js
@@ -11,7 +11,7 @@ const DEFAULT_COLUMN_PATHS = [
   "formattedDate",
   "@type",
   "lastlocation.rawlocationsensor",
-  "lastlocation.locationsensor",
+  "lastlocationResponse.locationsensor",
   "response.vehiclestate",
   "response.state",
   "response.tripstatus",

--- a/src/LogTable.js
+++ b/src/LogTable.js
@@ -245,6 +245,7 @@ function LogTable(props) {
           className: "logtable-cell short-column",
           solutionTypes: ["ODRD", "LMFS"],
         },
+
         {
           Header: "Sensor",
           accessor: "lastlocation.rawlocationsensor",
@@ -257,8 +258,8 @@ function LogTable(props) {
         },
         {
           Header: "Location",
-          accessor: "lastlocation.locationsensor",
-          id: "lastlocation_locationsensor",
+          accessor: "lastlocationResponse.locationsensor",
+          id: "lastlocationResponse_locationsensor",
           Cell: TrimCellRenderer,
           trim: "_LOCATION_PROVIDER",
           width: columnRegularWidth,

--- a/src/MapToggles.js
+++ b/src/MapToggles.js
@@ -8,7 +8,7 @@ export const ALL_TOGGLES = [
     id: "showGPSBubbles",
     name: "Location Accuracy",
     docLink: "https://github.com/googlemaps/fleet-debugger/blob/main/docs/GPSAccuracy.md",
-    columns: ["lastlocation.rawlocationaccuracy", "lastlocation.locationsensor"],
+    columns: ["lastlocationResponse.rawlocationaccuracy", "lastlocationResponse.locationsensor"],
     solutionTypes: ["ODRD", "LMFS"],
   },
   {
@@ -134,10 +134,10 @@ export function getToggleHandlers({
       bubbleMapRef.current[bubbleName] = tripLogs
         .getLogs_(minDate, maxDate)
         .map((le) => {
-          const rawloc = le.lastlocation?.rawlocation;
+          const rawloc = le.lastlocationResponse?.location || le.lastlocationResponse?.rawlocation;
           if (rawloc && typeof rawloc.latitude === "number" && typeof rawloc.longitude === "number") {
             const latLng = new window.google.maps.LatLng(rawloc.latitude, rawloc.longitude);
-            return cb(latLng, le.lastlocation, le);
+            return cb(latLng, le.lastlocationResponse, le);
           }
           return null;
         })
@@ -147,9 +147,9 @@ export function getToggleHandlers({
   };
 
   return {
-    showGPSBubbles: GenerateBubbles("showGPSBubbles", (rawLocationLatLng, lastLocation) => {
+    showGPSBubbles: GenerateBubbles("showGPSBubbles", (rawLocationLatLng, lastlocationResponse) => {
       let color;
-      switch (lastLocation.locationsensor) {
+      switch (lastlocationResponse.locationsensor) {
         case "GPS":
           color = "#11FF11";
           break;
@@ -169,7 +169,7 @@ export function getToggleHandlers({
         default:
           color = "#000000";
       }
-      const accuracy = lastLocation.rawlocationaccuracy;
+      const accuracy = lastlocationResponse.rawlocationaccuracy;
       if (accuracy) {
         const circ = new window.google.maps.Circle({
           strokeColor: color,

--- a/src/TripLogs.js
+++ b/src/TripLogs.js
@@ -192,6 +192,16 @@ function processRawLogs(rawLogs, solutionType) {
         newLog.lastlocationResponse.heading = lastKnownState.responseHeading;
       }
 
+      const updateMask = _.get(newLog, "request.updatemask") || "";
+      if (
+        currentResponseLocation &&
+        !newLog.lastlocationResponse.locationsensor &&
+        !newLog.request?.header &&
+        updateMask.includes("last_location")
+      ) {
+        newLog.lastlocationResponse.locationsensor = "API";
+      }
+
       // Update lastKnownState for next iterations
       const locToStore = currentLocation?.location || currentLocation?.rawlocation;
       if (locToStore) {


### PR DESCRIPTION
The sensor accepted by the Fleet Engine server is more useful to show than the primary sensor on the device which is usually static as ROAD_SNAPPED. Also added "API" as the type for when the location data was updated by the server instead of an SDK update.
